### PR TITLE
custom_hostname: Allow defining pagination options for custom hostnam…

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -505,6 +505,35 @@ type reqOption struct {
 	params url.Values
 }
 
+type TypedReqOption func(opt *ReqOptions)
+
+type ReqOptions struct {
+	Page      string
+	PerPage   string
+	ZoneName  string
+	AccountId string
+	Status    string
+}
+
+func WithTypedPagination(opts PaginationOptions) TypedReqOption {
+	return func(r *ReqOptions) {
+		r.Page = strconv.Itoa(opts.Page)
+		r.PerPage = strconv.Itoa(opts.PerPage)
+	}
+}
+
+func ApplyReqOptions(opts []TypedReqOption) *ReqOptions {
+	reqOptions := &ReqOptions{
+		Page:    "1",
+		PerPage: "20",
+	}
+	for _, applyFunc := range opts {
+		applyFunc(reqOptions)
+	}
+
+	return reqOptions
+}
+
 // WithZoneFilters applies a filter based on zone properties.
 func WithZoneFilters(zoneName, accountID, status string) ReqOption {
 	return func(opt *reqOption) {

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -219,10 +218,14 @@ func (api *API) CreateCustomHostname(ctx context.Context, zoneID string, ch Cust
 // The returned ResultInfo can be used to implement pagination.
 //
 // API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames
-func (api *API) CustomHostnames(ctx context.Context, zoneID string, page int, filter CustomHostname) ([]CustomHostname, ResultInfo, error) {
+func (api *API) CustomHostnames(ctx context.Context, zoneID string,
+	filter CustomHostname, opts ...TypedReqOption) ([]CustomHostname, ResultInfo, error) {
+
+	reqOptions := ApplyReqOptions(opts)
+
 	v := url.Values{}
-	v.Set("per_page", "50")
-	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", reqOptions.PerPage)
+	v.Set("page", reqOptions.Page)
 	if filter.Hostname != "" {
 		v.Set("hostname", filter.Hostname)
 	}
@@ -262,7 +265,7 @@ func (api *API) CustomHostname(ctx context.Context, zoneID string, customHostnam
 
 // CustomHostnameIDByName retrieves the ID for the given hostname in the given zone.
 func (api *API) CustomHostnameIDByName(ctx context.Context, zoneID string, hostname string) (string, error) {
-	customHostnames, _, err := api.CustomHostnames(ctx, zoneID, 1, CustomHostname{Hostname: hostname})
+	customHostnames, _, err := api.CustomHostnames(ctx, zoneID, CustomHostname{Hostname: hostname})
 	if err != nil {
 		return "", fmt.Errorf("CustomHostnames command failed: %w", err)
 	}

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -455,7 +455,7 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 }`)
 	})
 
-	customHostnames, _, err := client.CustomHostnames(context.Background(), "foo", 1, CustomHostname{})
+	customHostnames, _, err := client.CustomHostnames(context.Background(), "foo", CustomHostname{})
 
 	want := []CustomHostname{
 		{


### PR DESCRIPTION
Not compatible with cloudflare-go because that library has specific function params which would make this a breaking change to move to functional options (or even just adding per_page)